### PR TITLE
add dockerfile which runs blast-radius from source-dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-#usage
+#howto build docker image (from working-directory having blast-radius source)
+#  docker build -t blast-radius .
 #
-#docker run -it --rm -p 5000:5000 -v $(pwd):/workdir blast-radius
+#howto run docker container (from working-directory having *.tf files)
+#  docker run -it --rm -p 5000:5000 -v $(pwd):/workdir blast-radius
 
-#use latest tag for now for terraform version tag
+#use latest tag for now for terraform version
 FROM hashicorp/terraform:latest
 
 #expose blast-radius port

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+#Dockerfile to encapsulate both terraform and blast-radius
+#
 #howto build docker image (from working-directory having blast-radius source)
 #  docker build -t blast-radius .
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+#usage
+#
+#docker run -it --rm -p 5000:5000 -v $(pwd):/workdir blast-radius
+
+#use latest tag for now for terraform version tag
+FROM hashicorp/terraform:latest
+
+#expose blast-radius port
+EXPOSE 5000
+
+#install graphviz and py dependencies
+RUN apk --update --no-cache add graphviz font-bitstream-type1 && \
+    apk add --no-cache python3 && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
+
+#create package from source
+WORKDIR /src
+COPY . .
+RUN pip3 install -e .
+
+#set up entrypoint script
+RUN chmod +x ./docker-entrypoint.sh
+
+#set up runtime workdir for tf files
+WORKDIR /workdir
+ENTRYPOINT ["/src/docker-entrypoint.sh"]
+CMD ["--serve"]

--- a/bin/blast-radius
+++ b/bin/blast-radius
@@ -37,7 +37,7 @@ def main():
 
     if args.serve:
         os.chdir(args.directory)
-        app.run()
+        app.run(host='0.0.0.0')
         sys.exit(0)
     
     elif args.json or args.dot or args.svg:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-echo $1 $2 $3
-
 terraform init
+
 blast-radius $1 $2 $3
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+echo $1 $2 $3
+
+terraform init
+blast-radius $1 $2 $3
+


### PR DESCRIPTION
simple cut at a docker image as an alternative way to run blast-radius - good way to have others on my team try it without installing the py packages

builds blast-radius from source

runs 'terraform init' then blastradius