### PR TITLE
Allow for running on an alternate port

### DIFF
--- a/bin/blast-radius
+++ b/bin/blast-radius
@@ -21,7 +21,8 @@ def main():
 
     parser = parser = argparse.ArgumentParser(description='blast-radius: Interactive Terraform Graph Visualizations')
     parser.add_argument('directory', type=str, help='terraform configuration directory', default=os.getcwd(), nargs='?')
-
+    parser.add_argument('port', type=int, help='specify a port other than the default 5000', default=os.getenv('BLAST_RADIUS_PORT',5000), nargs='?')
+    
     output_group = parser.add_mutually_exclusive_group()
     output_group.add_argument('--json', action='store_const', const=True, default=False, help='print a json representation of the Terraform graph')
     output_group.add_argument('--dot', action='store_const', const=True, default=False, help='print the graphviz/dot representation of the Terraform graph')
@@ -45,7 +46,7 @@ def main():
 
     if args.serve:
         os.chdir(args.directory)
-        app.run(host='0.0.0.0')
+        app.run(host='0.0.0.0',port=args.port)
         sys.exit(0)
     
     elif args.json or args.dot or args.svg:


### PR DESCRIPTION
If specified, blast radius will bind to an alternate port. (More useful for those who pip install, versus using a docker container)