### PR TITLE
Add app.terraform.io to match new TFE module registry

### DIFF
--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -42,8 +42,11 @@ class Terraform:
                 # 'github.com' special behavior.
                 elif re.match(r'github\.com.*', source):
                     continue
-                # points to module registry.
+                # points to legacy TFE module registry.
                 elif re.match(r'hashicorp.*', source):
+                    continue
+                # points to new TFE module registry
+                elif re.match(r'app\.terraform\.io', source):
                     continue
                 # fixme path join. eek.
                 self.modules[name] = Terraform(directory=self.directory+'/'+source, settings=mod)


### PR DESCRIPTION
While trying to get to the bottom of https://github.com/28mm/blast-radius/issues/31 I found that at least one of my issues was because I have a module pointing at the new TFE module registry URL app.terraform.io.