### PR TITLE
Remove old hashicorp.com module registry match

### DIFF
--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -4,7 +4,7 @@ import io
 import os
 import re
 
-# 3rd party libraries 
+# 3rd party libraries
 import hcl    # hashicorp configuration language (.tf)
 
 class Terraform:
@@ -42,9 +42,6 @@ class Terraform:
                 # 'github.com' special behavior.
                 elif re.match(r'github\.com.*', source):
                     continue
-                # points to legacy TFE module registry.
-                elif re.match(r'hashicorp.*', source):
-                    continue
                 # points to new TFE module registry
                 elif re.match(r'app\.terraform\.io', source):
                     continue
@@ -62,13 +59,13 @@ class Terraform:
         # FIXME 'data' resources (incorrectly) handled as modules, necessitating
         # the try/except block here.
         if len(node.modules) > module_depth and node.modules[0] != 'root':
-            try: 
+            try:
                 tf = self.modules[ node.modules[module_depth] ]
                 return tf.get_def(node, module_depth=module_depth+1)
             except:
                 return ''
 
-        try: 
+        try:
             # non resource types
             types = { 'var'  : lambda x: self.config['variable'][x.resource_name],
             'provider'     : lambda x: self.config['provider'][x.resource_name],
@@ -81,7 +78,7 @@ class Terraform:
                 return types[node.type](node)
 
             # resources are a little different _many_ possible types,
-            # nested within the 'resource' field. 
+            # nested within the 'resource' field.
             else:
                 return self.config['resource'][node.type][node.resource_name]
         except:


### PR DESCRIPTION
As per [this](https://www.hashicorp.com/blog/hashicorp-terraform-enterprise-general-availability) blog post:

> The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, May 31, 2018. "Atlas" has been renamed to Terraform Enterprise and the features being developed are focusing on Terraform.

As part of this, the old Terraform Enterprise registry at `hashicorp.com` has been decommed, so its no longer needed.