### PR TITLE
Add support for Mercurial module sources

### DIFF
--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -51,7 +51,14 @@ class Terraform:
                 # bitbucket public and private repos
                 elif re.match(r'bitbucket\.org.*', source):
                     continue
-                elif re.match(r'git\:\:.*', source):
+                # git::https or git::ssh sources
+                elif re.match(r'^git::', source):
+                    continue
+                # git:// sources
+                elif re.match(r'^git:\/\/', source):
+                    continue
+                # Generic Mercurial repos
+                elif re.match(r'^hg::', source):
                     continue
                 # fixme path join. eek.
                 self.modules[name] = Terraform(directory=self.directory+'/'+source, settings=mod)


### PR DESCRIPTION
Match on sources from `hg::` as per [the documentation](https://www.terraform.io/docs/modules/sources.html#generic-mercurial-repository)