### PR TITLE
ubuntu 18.04, workaround #60, terraform 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@
 #Implementation notes
 # Using ubuntu (rather than alpine) base image due to problems with graphviz fonts on alpine
 
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 #define default terraform version in environment var
-ENV TF_VERSION "0.11.13"
+ENV TF_VERSION "0.12.0"
 
 #expose blast-radius port
 EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Point *Blast Radius* at an `init-ed` *Terraform* project, and connect with your 
 *Alternatively*, you can launch *Blast Radius* in a docker container. (In this example, the current working directory contains a *Terraform* project.)
 
 ```bash
-[...]$ docker run --cap-add=SYS_ADMIN -it --rm -p 5000:5000 -v $(pwd):/workdir:ro 28mm/blast-radius
+[...]$ docker run --security-opt apparmor:unconfined --cap-add=SYS_ADMIN -it --rm -p 5000:5000 -v $(pwd):/workdir:ro 28mm/blast-radius
 ```
 
 *Please note*: because terraform saves module links as _absolute_ paths in _.terraform/modules/<uuid>_ we mount the host's filesystem read-only and force terraform to update the modules path at start. This way we don't interfere with the real project. Thus docker has to be run with the `--cap-add=SYS_ADMIN` flag to use the [overlayFS](https://wiki.archlinux.org/index.php/Overlay_filesystem) see [Docker's documentation](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).


### PR DESCRIPTION
Upgrade to ubuntu 18.04 LTS, add --security-opt apparmor:unconfined to docker docs (workaround for #60), use terraform 0.12.0