### PR TITLE
Upgrade to terraform 0.12.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
   buildpack:
     environment:
       IMAGE_NAME: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-      TF_VERSION: 0.12.3
+      TF_VERSION: 0.12.12
     docker:
       - image: circleci/buildpack-deps
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TF_VERSION=0.12.3
+ARG TF_VERSION=0.12.12
 ARG PYTHON_VERSION=3.7
 
 FROM hashicorp/terraform:$TF_VERSION AS terraform


### PR DESCRIPTION
Upgrade to terraform 0.12.12

I run into state errors using latest terraform with blast radius, so I updated the tf version.

It appears circleci is not happy with the configuration change I provided. I don't think there is anything I can do to resolve that issue though, @28mm will have to clear the docker cache I believe to resolve that.