### PR TITLE
Handle Remote Modules and Fix HCL Parsing

### DIFF
--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -5,7 +5,7 @@ import os
 import re
 
 # 3rd party libraries
-import hcl    # hashicorp configuration language (.tf)
+import hcl2 as hcl    # hashicorp configuration language (.tf)
 
 class Terraform:
     """Finds terraform/hcl files (*.tf) in CWD or a supplied directory, parses
@@ -21,7 +21,7 @@ class Terraform:
         iterator = iglob( self.directory + '/*.tf')
         for fname in iterator:
             with open(fname, 'r', encoding='utf-8') as f:
-                self.config_str += f.read() + ' '
+                self.config_str += f.read() + '\n'
         config_io = io.StringIO(self.config_str)
         self.config = hcl.load(config_io)
 
@@ -29,10 +29,10 @@ class Terraform:
         # the time being.
         self.modules = {}
         if 'module' in self.config:
-            for name, mod in self.config['module'].items():
+            for name, mod in [(k, v) for x in self.config['module'] for (k, v) in x.items()]:
                 if 'source' not in mod:
                     continue
-                source = mod['source']
+                source = mod['source'][0]
                 # '//' used to refer to a subdirectory in a git repo
                 if re.match(r'.*\/\/.*', source):
                     continue

--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -30,45 +30,32 @@ class Terraform:
                     raise RuntimeError('Exception occurred while parsing ' + fname) from e
 
 
-        # then any submodules it may contain, skipping any remote modules for
-        # the time being.
+        # then any submodules it may contain
         self.modules = {}
         if 'module' in self.config:
             for name, mod in [(k, v) for x in self.config['module'] for (k, v) in x.items()]:
                 if 'source' not in mod:
                     continue
                 source = mod['source'][0]
-                # '//' used to refer to a subdirectory in a git repo
-                if re.match(r'.*\/\/.*', source):
-                    continue
-                # '@' should only appear in ssh urls
-                elif re.match(r'.*\@.*', source):
-                    continue
-                # 'github.com' special behavior.
-                elif re.match(r'github\.com.*', source):
-                    continue
-                # points to new TFE module registry
-                elif re.match(r'app\.terraform\.io', source):
-                    continue
-                # bitbucket public and private repos
-                elif re.match(r'bitbucket\.org.*', source):
-                    continue
-                # git::https or git::ssh sources
-                elif re.match(r'^git::', source):
-                    continue
-                # git:// sources
-                elif re.match(r'^git:\/\/', source):
-                    continue
-                # Generic Mercurial repos
-                elif re.match(r'^hg::', source):
-                    continue
-                # Public Terraform Module Registry
-                elif re.match(r'^[a-zA-Z0-9\-_]+\/[a-zA-Z0-9\-_]+\/[a-zA-Z0-9\-_]+', source):
-                    continue
-                # AWS S3 buckets
-                elif re.match(r's3.*\.amazonaws\.com', source):
-                    continue
-                self.modules[name] = Terraform(directory=os.path.join(self.directory, source), settings=mod)
+                
+                path = os.path.join(self.directory, source)
+                if os.path.exists(path):
+                    # local module
+                    self.modules[name] = Terraform(directory=path, settings=mod)
+                else:
+                    # remote module
+                    # Since terraform must be init'd before use, we can
+                    # assume remote modules have been downloaded to .terraform/modules
+                    path = os.path.join(os.getcwd(), '.terraform', 'modules', name)
+                    
+                    # Get the subdir if any
+                    match = re.match(r'.*(\/\/.*)(?!:)', source)
+                    if re.match(r'.*\/(\/.*)(?!:)', source):
+                        path = os.path.join(path, match.groups()[0])
+                    
+                    self.modules = Terraform(directory=path, settings=mod)
+
+                
 
 
     def get_def(self, node, module_depth=0):

--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -17,13 +17,18 @@ class Terraform:
         # handle the root module first...
         self.directory = directory if directory else os.getcwd()
         #print(self.directory)
-        self.config_str = ''
+        
+        self.config = {}
         iterator = iglob( self.directory + '/*.tf')
         for fname in iterator:
             with open(fname, 'r', encoding='utf-8') as f:
-                self.config_str += f.read() + '\n'
-        config_io = io.StringIO(self.config_str)
-        self.config = hcl.load(config_io)
+                try:
+                    raw = io.StringIO(f.read())
+                    parsed = hcl.load(raw)
+                    self.config.update(parsed)
+                except Exception as e:
+                    raise RuntimeError('Exception occurred while parsing ' + fname) from e
+
 
         # then any submodules it may contain, skipping any remote modules for
         # the time being.

--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -68,8 +68,7 @@ class Terraform:
                 # AWS S3 buckets
                 elif re.match(r's3.*\.amazonaws\.com', source):
                     continue
-                # fixme path join. eek.
-                self.modules[name] = Terraform(directory=self.directory+'/'+source, settings=mod)
+                self.modules[name] = Terraform(directory=os.path.join(self.directory, source), settings=mod)
 
 
     def get_def(self, node, module_depth=0):

--- a/blastradius/server/static/js/blast-radius.js
+++ b/blastradius/server/static/js/blast-radius.js
@@ -138,6 +138,12 @@ blastradius = function (selector, svg_url, json_url, br_state) {
                     svg_nodes.push(node);
                 });
             } else {
+                let div = document.createElement("div")
+                div.setAttribute("role", "alert")
+                div.classList = ["alert alert-danger"]
+                div.textContent = "A server exception has occurred. The graph is still usable but without all features enabled such as filtering content"
+                document.getElementsByClassName("navbar")[0].appendChild(div)
+                
                 edges = []
             }
 

--- a/blastradius/server/static/js/blast-radius.js
+++ b/blastradius/server/static/js/blast-radius.js
@@ -521,8 +521,6 @@ blastradius = function (selector, svg_url, json_url, br_state) {
                 var svg_el       = document.querySelector(selector + ' svg');
                 var panzoom      = svgPanZoom(svg_el).disableDblClickZoom();
 
-                console.log('bang');
-                console.log(state);
                 if (state['no_scroll_zoom'] == true) {
                     console.log('bang');
                     panzoom.disableMouseWheelZoom();

--- a/blastradius/server/static/js/blast-radius.js
+++ b/blastradius/server/static/js/blast-radius.js
@@ -122,19 +122,24 @@ blastradius = function (selector, svg_url, json_url, br_state) {
         // d3.xml success callback, to guaruntee the svg/xml
         // has loaded.
         d3.json(json_url, function (error, data) {
-            var edges = data.edges;
-            var svg_nodes = [];
-            var nodes = {};
-            data.nodes.forEach(function (node) {
-                if (!(node.type in resource_groups))
-                    console.log(node.type)
-                if (node.label == '[root] root') { // FIXME: w/ tf 0.11.2, resource_name not set by server.
-                    node.resource_name = 'root';
-                }
-                node.group = (node.type in resource_groups) ? resource_groups[node.type] : -1;
-                nodes[node['label']] = node;
-                svg_nodes.push(node);
-            });
+            if (!error) {
+                console.log("An error occurred on the server")
+                var edges = data.edges;
+                var svg_nodes = [];
+                var nodes = {};
+                data.nodes.forEach(function (node) {
+                    if (!(node.type in resource_groups))
+                        console.log(node.type)
+                    if (node.label == '[root] root') { // FIXME: w/ tf 0.11.2, resource_name not set by server.
+                        node.resource_name = 'root';
+                    }
+                    node.group = (node.type in resource_groups) ? resource_groups[node.type] : -1;
+                    nodes[node['label']] = node;
+                    svg_nodes.push(node);
+                });
+            } else {
+                edges = []
+            }
 
             // convenient to access edges by their source.
             var edges_by_source = {}
@@ -449,23 +454,25 @@ blastradius = function (selector, svg_url, json_url, br_state) {
             }
 
             // colorize nodes, and add mouse candy.
-            svg.selectAll('g.node')
-                .data(svg_nodes, function (d) {
-                    return (d && d.svg_id) || d3.select(this).attr("id");
-                })
-                .on('mouseenter', node_mouseenter)
-                .on('mouseleave', node_mouseleave)
-                .on('mouseover', node_mouseover)
-                .on('mouseout', node_mouseout)
-                .on('mousedown', node_mousedown)
-                .attr('fill', function (d) { return color(d.group); })
-                .select('polygon:nth-last-of-type(2)')
-                .style('fill', (function (d) {
-                    if (d)
-                        return color(d.group);
-                    else
-                        return '#000';
-                }));
+            if (svg_nodes) {
+                svg.selectAll('g.node')
+                    .data(svg_nodes, function (d) {
+                        return (d && d.svg_id) || d3.select(this).attr("id");
+                    })
+                    .on('mouseenter', node_mouseenter)
+                    .on('mouseleave', node_mouseleave)
+                    .on('mouseover', node_mouseover)
+                    .on('mouseout', node_mouseout)
+                    .on('mousedown', node_mousedown)
+                    .attr('fill', function (d) { return color(d.group); })
+                    .select('polygon:nth-last-of-type(2)')
+                    .style('fill', (function (d) {
+                        if (d)
+                            return color(d.group);
+                        else
+                            return '#000';
+                    }));
+            }
 
             // colorize modules
             svg.selectAll('polygon')
@@ -481,22 +488,24 @@ blastradius = function (selector, svg_url, json_url, br_state) {
             });
 
             // hack to make mouse events and coloration work on the root node again.
-            var root = nodes['[root] root'];
-            svg.selectAll('g.node#' + root.svg_id)
-                .data(svg_nodes, function (d) {
-                    return (d && d.svg_id) || d3.select(this).attr("id");
-                })
-                .on('mouseover', node_mouseover)
-                .on('mouseout', node_mouseout)
-                .on('mousedown', node_mousedown)
-                .select('polygon')
-                .attr('fill', function (d) { return color(d.group); })
-                .style('fill', (function (d) {
-                    if (d)
-                        return color(d.group);
-                    else
-                        return '#000';
-                }));
+            if (nodes) {
+                var root = nodes['[root] root'];
+                svg.selectAll('g.node#' + root.svg_id)
+                    .data(svg_nodes, function (d) {
+                        return (d && d.svg_id) || d3.select(this).attr("id");
+                    })
+                    .on('mouseover', node_mouseover)
+                    .on('mouseout', node_mouseout)
+                    .on('mousedown', node_mousedown)
+                    .select('polygon')
+                    .attr('fill', function (d) { return color(d.group); })
+                    .style('fill', (function (d) {
+                        if (d)
+                            return color(d.group);
+                        else
+                            return '#000';
+                    }));
+            }
 
             // stub, in case we want to do something with edges on init.
             svg.selectAll('g.edge')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Jinja2==2.10.1
 Flask==1.0.3
 beautifulsoup4==4.7.1
 ply>=3.11
-pyhcl==0.3.12
+python-hcl2==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,5 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     scripts=['bin/blast-radius'],
     install_requires=reqs,
+    include_package_data=True
 )


### PR DESCRIPTION
This does a variety of things that hopefully help out.

## Change from using `pyhcl` to using `python-hcl2`
From my understanding terraform, by default, uses hcl2 now. The readme of `pyhcl` mentions that it does not support hcl2 (and therefore modern terraform). Changing to hcl2 seemed to clear up a lot of the `unexpected X` errors as well. However, there's still a goofy one when using `:` in place of `=` such as this:
```
app_settings = {
    "SOME_VAR": "SOME VALUE"
}
```
but this is an easy fix to just change the colons to equals

## Improve error handling when parsing hcl
I changed up the way the tf files are loaded so that each file is loaded individually rather than creating a big combined one and then saving that to the `Terraform.config`. This way, we can throw an exception that's a little more indicative of where the problem is. 

For example, if my file for the issue with colons described above is called `myfunc.tf` then when that is loaded, the exception thrown will read:
```
Traceback (most recent call last):
...
RuntimeError: Exception occurred while parsing /path/to/myfunc.tf
```

## Use `os.path.join`
Noticed a comment in `terraform.py` about using path.join instead of the concat by addition so I changed that up

## Handle remote module
Probably the pièce de résistance of this PR. Added the ability to handle remote modules (at least I think this should handle _most_ cases). Since we require the terraform config to be init'd, we can assume all remote modules are found under .terrform of the topmost dir of the config. From here it's just about getting the right path out of the source description which a simple enough regex does the trick to split things. I tried this on a handful of sources including:
- local modules (just to make sure nothing broke)
- terraform registry
- git using ssh
- github.com

## Make viewer usable on parsing failure
Even if the server fails, I personally want to be able to move around the graph it creates even if I don't get the full functionality, so I did just that. When the server fails to parse, the chart is still semi usable and an alert is added to the navbar to indicate that a server exception occurred